### PR TITLE
Fix plugin hub incompatibility (ComponentID / getMapAngle removed)

### DIFF
--- a/src/main/java/com/herbiafk/QuestHelperTools/QuestPerspective.java
+++ b/src/main/java/com/herbiafk/QuestHelperTools/QuestPerspective.java
@@ -36,8 +36,8 @@ import net.runelite.api.RenderOverview;
 import net.runelite.api.Varbits;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.ComponentID;
 
 
 public class QuestPerspective
@@ -149,16 +149,16 @@ public class QuestPerspective
             if (client.getVarbitValue(Varbits.SIDE_PANELS) == 1)
             {
 
-                minimapDrawWidget = client.getWidget(ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_MINIMAP_DRAW_AREA);
+                minimapDrawWidget = client.getWidget(InterfaceID.ToplevelPreEoc.MINIMAP);
             }
             else
             {
-                minimapDrawWidget = client.getWidget(ComponentID.RESIZABLE_VIEWPORT_MINIMAP_DRAW_AREA);
+                minimapDrawWidget = client.getWidget(InterfaceID.ToplevelOsrsStretch.MINIMAP);
             }
         }
         else
         {
-            minimapDrawWidget = client.getWidget(ComponentID.FIXED_VIEWPORT_MINIMAP_DRAW_AREA);
+            minimapDrawWidget = client.getWidget(InterfaceID.Toplevel.MINIMAP);
         }
 
         if (minimapDrawWidget == null)
@@ -166,7 +166,7 @@ public class QuestPerspective
             return null;
         }
 
-        final int angle = client.getMapAngle() & 0x7FF;
+        final int angle = client.getCameraYawTarget() & 0x7FF;
 
         final int sin = Perspective.SINE[angle];
         final int cos = Perspective.COSINE[angle];

--- a/src/main/java/com/herbiafk/QuestHelperTools/WorldLines.java
+++ b/src/main/java/com/herbiafk/QuestHelperTools/WorldLines.java
@@ -37,7 +37,7 @@ import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
@@ -70,15 +70,15 @@ public class WorldLines
             Line2D.Double line = new Line2D.Double(startPosOnMinimap.getX(), startPosOnMinimap.getY(), destinationPosOnMinimap.getX(), destinationPosOnMinimap.getY());
 
             Rectangle bounds = new Rectangle(0, 0, client.getCanvasWidth(), client.getCanvasHeight());
-            Widget minimapWidget = client.getWidget(ComponentID.RESIZABLE_VIEWPORT_MINIMAP_DRAW_AREA);
+            Widget minimapWidget = client.getWidget(InterfaceID.ToplevelOsrsStretch.MINIMAP);
 
             if (minimapWidget == null)
             {
-                minimapWidget = client.getWidget(ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_MINIMAP_DRAW_AREA);
+                minimapWidget = client.getWidget(InterfaceID.ToplevelPreEoc.MINIMAP);
             }
             if (minimapWidget == null)
             {
-                minimapWidget = client.getWidget(ComponentID.FIXED_VIEWPORT_MINIMAP_DRAW_AREA);
+                minimapWidget = client.getWidget(InterfaceID.Toplevel.MINIMAP);
             }
 
             if (minimapWidget != null)


### PR DESCRIPTION
Fixes #16 

The plugin currently shows up as incompatible on the hub because it no longer compiles against the latest RuneLite. Two things it uses were removed from the API: `ComponentID` (now `gameval.InterfaceID`) and `Client.getMapAngle()` (now `getCameraYawTarget()`, which it used to be a deprecated alias of). This swaps both over so it builds again.

I kept this PR to just the parts that actually break the build. There are a few remaining deprecation warnings (`getRenderOverview`, `Varbits`, some `WorldView` stuff) that still compile fine for now.

Verified with `./gradlew compileJava` against `net.runelite:client:latest.release`.

Tested:
<img width="497" height="416" alt="image" src="https://github.com/user-attachments/assets/112b5d31-7f89-4dc5-9a85-389a8e2d3569" />
